### PR TITLE
Feature/optimize osyield

### DIFF
--- a/test/benchmark_test.go
+++ b/test/benchmark_test.go
@@ -2,7 +2,9 @@ package test
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
+	"time"
 )
 
 func BenchmarkCallRequestWithNilParamsOnSubscribedModel(b *testing.B) {
@@ -63,4 +65,80 @@ func BenchmarkCallRequestWithNilParamsOnSubscribedModelParallel(b *testing.B) {
 	})
 
 	teardown(s)
+}
+
+func BenchmarkCustomEventSubscribers1(b *testing.B) {
+	benchmarkCustomEvent(b, 1)
+}
+
+func BenchmarkCustomEventSubscribers10(b *testing.B) {
+	benchmarkCustomEvent(b, 10)
+}
+
+func BenchmarkCustomEventSubscribers100(b *testing.B) {
+	benchmarkCustomEvent(b, 100)
+}
+
+func BenchmarkCustomEventSubscribers1000(b *testing.B) {
+	benchmarkCustomEvent(b, 1000)
+}
+
+func BenchmarkCustomEventSubscribers10000(b *testing.B) {
+	benchmarkCustomEvent(b, 10000)
+}
+
+func benchmarkCustomEvent(b *testing.B, subscribers int) {
+	var s *Session
+	panicked := true
+	defer func() {
+		if panicked {
+			fmt.Printf("Trace log:\n%s", s.l)
+		}
+	}()
+
+	s = setup()
+	cs := make([]*Conn, subscribers)
+	evs := make(chan *ClientEvent, subscribers+10)
+	model := resource["test.model"]
+	// customEvent := json.RawMessage(`{"foo":"bar"}`)
+
+	for i := 0; i < subscribers; i++ {
+		c := s.ConnectWithChannel(evs)
+		cs[i] = c
+		// Subscribe to resource
+		creq := c.Request("subscribe.test.model", nil)
+		if i == 0 {
+			// Handle model get and access request
+			mreqs := s.GetParallelRequests(nil, 2)
+			req := mreqs.GetRequest(nil, "access.test.model")
+			req.RespondSuccess(json.RawMessage(`{"get":true,"call":"*"}`))
+			req = mreqs.GetRequest(nil, "get.test.model")
+			req.RespondSuccess(json.RawMessage(`{"model":` + model + `}`))
+		} else {
+			s.
+				GetRequest(nil).
+				AssertSubject(nil, "access.test.model").
+				RespondSuccess(json.RawMessage(`{"get":true,"call":"*"}`))
+		}
+		// Get client response
+		creq.GetResponse(nil)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Send event on model and validate client event
+		s.ResourceEvent("test.model", "custom", nil)
+		// Wait for all the events
+		for i := 0; i < subscribers; i++ {
+			select {
+			case ev := <-evs:
+				ev.AssertEventName(nil, "test.model.custom")
+			case <-time.After(timeoutSeconds * time.Second):
+				panic("expected a client event but found none")
+			}
+		}
+	}
+
+	teardown(s)
+	panicked = false
 }

--- a/test/benchmark_test.go
+++ b/test/benchmark_test.go
@@ -2,9 +2,7 @@ package test
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
-	"time"
 )
 
 func BenchmarkCallRequestWithNilParamsOnSubscribedModel(b *testing.B) {
@@ -65,80 +63,4 @@ func BenchmarkCallRequestWithNilParamsOnSubscribedModelParallel(b *testing.B) {
 	})
 
 	teardown(s)
-}
-
-func BenchmarkCustomEventSubscribers1(b *testing.B) {
-	benchmarkCustomEvent(b, 1)
-}
-
-func BenchmarkCustomEventSubscribers10(b *testing.B) {
-	benchmarkCustomEvent(b, 10)
-}
-
-func BenchmarkCustomEventSubscribers100(b *testing.B) {
-	benchmarkCustomEvent(b, 100)
-}
-
-func BenchmarkCustomEventSubscribers1000(b *testing.B) {
-	benchmarkCustomEvent(b, 1000)
-}
-
-func BenchmarkCustomEventSubscribers10000(b *testing.B) {
-	benchmarkCustomEvent(b, 10000)
-}
-
-func benchmarkCustomEvent(b *testing.B, subscribers int) {
-	var s *Session
-	panicked := true
-	defer func() {
-		if panicked {
-			fmt.Printf("Trace log:\n%s", s.l)
-		}
-	}()
-
-	s = setup()
-	cs := make([]*Conn, subscribers)
-	evs := make(chan *ClientEvent, subscribers+10)
-	model := resource["test.model"]
-	// customEvent := json.RawMessage(`{"foo":"bar"}`)
-
-	for i := 0; i < subscribers; i++ {
-		c := s.ConnectWithChannel(evs)
-		cs[i] = c
-		// Subscribe to resource
-		creq := c.Request("subscribe.test.model", nil)
-		if i == 0 {
-			// Handle model get and access request
-			mreqs := s.GetParallelRequests(nil, 2)
-			req := mreqs.GetRequest(nil, "access.test.model")
-			req.RespondSuccess(json.RawMessage(`{"get":true,"call":"*"}`))
-			req = mreqs.GetRequest(nil, "get.test.model")
-			req.RespondSuccess(json.RawMessage(`{"model":` + model + `}`))
-		} else {
-			s.
-				GetRequest(nil).
-				AssertSubject(nil, "access.test.model").
-				RespondSuccess(json.RawMessage(`{"get":true,"call":"*"}`))
-		}
-		// Get client response
-		creq.GetResponse(nil)
-	}
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		// Send event on model and validate client event
-		s.ResourceEvent("test.model", "custom", nil)
-		// Wait for all the events
-		for i := 0; i < subscribers; i++ {
-			select {
-			case ev := <-evs:
-				ev.AssertEventName(nil, "test.model.custom")
-			case <-time.After(timeoutSeconds * time.Second):
-				panic("expected a client event but found none")
-			}
-		}
-	}
-
-	teardown(s)
-	panicked = false
 }

--- a/test/test.go
+++ b/test/test.go
@@ -42,15 +42,21 @@ func setup() *Session {
 	return s
 }
 
-// Connect makes a new mock client websocket connection
-func (s *Session) Connect() *Conn {
+// ConnectWithChannel makes a new mock client websocket connection
+// with a ClientEvent channel.
+func (s *Session) ConnectWithChannel(evs chan *ClientEvent) *Conn {
 	d := wstest.NewDialer(s.s.GetWSHandlerFunc())
 	c, _, err := d.Dial("ws://example.org/", nil)
 	if err != nil {
 		panic(err)
 	}
 
-	return NewConn(s, d, c)
+	return NewConn(s, d, c, evs)
+}
+
+// Connect makes a new mock client websocket connection
+func (s *Session) Connect() *Conn {
+	return s.ConnectWithChannel(make(chan *ClientEvent, 256))
 }
 
 // HTTPRequest sends a request over HTTP


### PR DESCRIPTION
High osyield in benchmark test turned out to be due to garbage produced by the client WebSockets used in the test, and not the Resgate itself.